### PR TITLE
enable HTTP body to be set via request options

### DIFF
--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -213,6 +213,10 @@ extension Request {
         case Header(String, String)
         /// Defines the cache policy to set in the `Request` value.
         case CachePolicy(NSURLRequestCachePolicy)
+        /// Defines the HTTP body contents of the HTTP request.
+        case Body(NSData)
+        /// Defines the JSON object that will be serialized as the body of the HTTP request.
+        case BodyJSON(AnyObject)
     }
     
     /// Uses an array of `Option` values as rules for mutating a `Request` value.
@@ -230,6 +234,12 @@ extension Request {
                 
             case .CachePolicy(let cachePolicy):
                 request.cachePolicy = cachePolicy
+                
+            case .Body(let data):
+                request.body = data
+                
+            case .BodyJSON(let json):
+                request.body = try? NSJSONSerialization.dataWithJSONObject(json, options: NSJSONWritingOptions(rawValue: 0))
             }
         }
         

--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -104,6 +104,9 @@ public struct Request {
     /// The URL string of the HTTP request.
     public let url: String
     
+    /// The body of the HTTP request.
+    public var body: NSData?
+    
     /**
      The parameters to encode in the HTTP request. Request parameters are percent
      encoded and are appended as a query string or set as the request body 
@@ -187,6 +190,11 @@ extension Request: URLRequestEncodable {
                     urlRequest.setValue(ContentType.formEncoded, forHTTPHeaderField: Headers.contentType)
                 }
             }
+        }
+        
+        // body property value overwrites any previously encoded body value
+        if let body = body {
+            urlRequest.HTTPBody = body
         }
 
         return urlRequest.copy() as! NSURLRequest

--- a/THGWebServiceTests/WebServiceTests.swift
+++ b/THGWebServiceTests/WebServiceTests.swift
@@ -268,6 +268,43 @@ class WebServiceTests: XCTestCase {
         waitForExpectationsWithTimeout(2, handler: nil)
     }
     
+    func testPostJSONEncodedArray() {
+        let successExpectation = expectationWithDescription("Received status 200")
+        let service = WebService(baseURLString: baseURL)
+        
+        let jsonObject = ["foo" : "bar", "number" : 42]
+        let jsonArray = [jsonObject, jsonObject]
+        
+        service
+            .POST("/post",
+                parameters: nil,
+                options: [
+                    .ParameterEncoding(.JSON),
+                    .BodyJSON(jsonArray)
+                ])
+            .response { data, response in
+                
+                let httpResponse = response as! NSHTTPURLResponse
+                
+                if httpResponse.statusCode == 200 {
+                    successExpectation.fulfill()
+                }
+            }
+            .responseJSON { json in
+                let castedJSON = json as? [String : AnyObject]
+                XCTAssert(castedJSON != nil)
+                
+                let deliveredArray = castedJSON!["json"] as? [[String : AnyObject]]
+                XCTAssert(deliveredArray != nil)
+                
+                for deliveredJSONObject in deliveredArray! {
+                    RequestTests.assertRequestParametersNotEqual(deliveredJSONObject, toOriginalParameters: jsonObject)
+                }
+        }
+        
+        waitForExpectationsWithTimeout(2, handler: nil)
+    }
+    
     func testHeadersDelivered() {
         let successExpectation = expectationWithDescription("Received status 200")
         let service = WebService(baseURLString: baseURL)


### PR DESCRIPTION

### summary

- add `.Body` and `.BodyJSON` request options to allow raw HTTP body contents to be defined
- add unit test for encoding a JSON array as the HTTP body of a request

### overview

this PR allows the raw HTTP body to be defined for a request using the newly added request options `Option.Body` and `Option.BodyJSON`. Defining a `NSData` value for the HTTP body will override any body contents that were previously encoded as a result of request parameters. 

```
/// Defines the HTTP body contents of the HTTP request.
case Body(NSData)

/// Defines the JSON object that will be serialized as the body of the HTTP request.
case BodyJSON(AnyObject)
```


The `.BodyJSON` option serializes an `AnyObject` value via `NSJSONSerialization.dataWithJSONObject` and sets it as the HTTP body contents. Below an array is serialized as JSON and sent as the HTTP body of the request.

```
let jsonArray = [["foo" : "bar", "number" : 42], ["foo" : "bar", "number" : 42]]

service
    .POST("/foo",
        parameters: nil,
        options: [
            .ParameterEncoding(.JSON),
            .BodyJSON(jsonArray)
        ])
    .responseJSON { json in
        // handle response
    }
```
This produces the HTTP request:
```
POST /post HTTP/1.1
Host: httpbin.org
Content-Type: application/json
Content-Length: 53

[{"number":42,"foo":"bar"},{"number":42,"foo":"bar"}]
```


The `.Body` option enables you define the raw HTTP body contents with a `NSData` value.

```
let jsonArray = [["foo" : "bar", "number" : 42], ["foo" : "bar", "number" : 42]]
let body: NSData = try? NSJSONSerialization.dataWithJSONObject(jsonArray, options: NSJSONWritingOptions(rawValue: 0))

service
    .POST("/foo",
        parameters: nil,
        options: [
            .Body(body)
        ])
    .responseJSON { json in
        // handle response
    }
```
