### PR TITLE
 add `.Body` and `.BodyJSON` request options to allow raw HTTP body contents to be defined

### DIFF
--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -97,6 +97,9 @@ public struct Request {
     /// The URL string of the HTTP request.
     public let url: String
     
+    /// The body of the HTTP request.
+    public var body: NSData?
+    
     /**
      The parameters to encode in the HTTP request. Request parameters are percent
      encoded and are appended as a query string or set as the request body
@@ -180,6 +183,11 @@ extension Request: URLRequestEncodable {
                 }
             }
         }
+        
+        // body property value overwrites any previously encoded body value
+        if let body = body {
+            urlRequest.HTTPBody = body
+        }
 
         return urlRequest.copy() as! NSURLRequest
     }
@@ -190,9 +198,16 @@ extension Request: URLRequestEncodable {
 extension Request {
     
     public enum Option {
+        /// Defines the parameter encoding for the HTTP request.
         case ParameterEncoding(Request.ParameterEncoding)
+        /// Defines a HTTP header field name and value to set in the `Request`.
         case Header(String, String)
+        /// Defines the cache policy to set in the `Request` value.
         case CachePolicy(NSURLRequestCachePolicy)
+        /// Defines the HTTP body contents of the HTTP request.
+        case Body(NSData)
+        /// Defines the JSON object that will be serialized as the body of the HTTP request.
+        case BodyJSON(AnyObject)
     }
     
     public func encodeOptions(options: [Option]) -> Request {
@@ -209,6 +224,12 @@ extension Request {
                 
             case .CachePolicy(let cachePolicy):
                 request.cachePolicy = cachePolicy
+                
+            case .Body(let data):
+                request.body = data
+                
+            case .BodyJSON(let json):
+                request.body = NSJSONSerialization.dataWithJSONObject(json, options: NSJSONWritingOptions(rawValue: 0), error: nil)
             }
         }
         


### PR DESCRIPTION
 add `.Body` and `.BodyJSON` request options to allow raw HTTP body contents to be defined

This is a back port of commit 49f046f4bd9c4e190eeec54321f08ec520cd13ef to address Swift 1.2 compatibility.