### PR TITLE
refactor request option API

### DIFF
--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -19,10 +19,6 @@ protocol URLRequestEncodable {
     var urlRequestValue: NSURLRequest {get}
 }
 
-protocol RequestEncoder {
-    func encodeRequest(method: Request.Method, url: String, parameters: [String : AnyObject]?, options: [Request.Option]?) -> Request
-}
-
 /**
  Encapsulates the data required to send an HTTP request.
 */
@@ -97,7 +93,7 @@ public struct Request {
         public static let formEncoded = "application/x-www-form-urlencoded"
         public static let json = "application/json"
     }
-    
+        
     /// The HTTP method of the request.
     public let method: Method
     
@@ -198,52 +194,6 @@ extension Request: URLRequestEncodable {
         }
 
         return urlRequest.copy() as! NSURLRequest
-    }
-}
-
-// MARK: - Request Options
-
-extension Request {
-    
-    /// An `Option` value defines a rule for encoding part of a `Request` value.
-    public enum Option {
-        /// Defines the parameter encoding for the HTTP request.
-        case ParameterEncoding(Request.ParameterEncoding)
-        /// Defines a HTTP header field name and value to set in the `Request`.
-        case Header(String, String)
-        /// Defines the cache policy to set in the `Request` value.
-        case CachePolicy(NSURLRequestCachePolicy)
-        /// Defines the HTTP body contents of the HTTP request.
-        case Body(NSData)
-        /// Defines the JSON object that will be serialized as the body of the HTTP request.
-        case BodyJSON(AnyObject)
-    }
-    
-    /// Uses an array of `Option` values as rules for mutating a `Request` value.
-    func encodeOptions(options: [Option]) -> Request {
-        var request = self
-        
-        for option in options {
-            switch option {
-                
-            case .ParameterEncoding(let encoding):
-                request.parameterEncoding = encoding
-                
-            case .Header(let name, let value):
-                request.headers[name] = value
-                
-            case .CachePolicy(let cachePolicy):
-                request.cachePolicy = cachePolicy
-                
-            case .Body(let data):
-                request.body = data
-                
-            case .BodyJSON(let json):
-                request.body = try? NSJSONSerialization.dataWithJSONObject(json, options: NSJSONWritingOptions(rawValue: 0))
-            }
-        }
-        
-        return request
     }
 }
 

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -127,7 +127,7 @@ extension ServiceTask {
     /// Resume the underlying data task.
     public func resume() -> Self {
         if dataTask == nil {
-            dataTask = dataTaskSource?.dataTaskWithRequest(request.urlRequestValue, completion: dataTaskCompletionHandler())
+            dataTask = dataTaskSource?.dataTaskWithRequest(request.urlRequestValue, completionHandler: dataTaskCompletionHandler())
         }
         
         dataTask?.resume()

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -15,6 +15,8 @@ import Foundation
  via the `state` property.
 */
 public final class ServiceTask {
+    private var request: Request
+    
     /// Represents the result of a service task.
     private enum Result {
         case Success(NSData?, NSURLResponse?)
@@ -54,6 +56,8 @@ public final class ServiceTask {
     /// Result of the service task
     private var result: Result?
     
+    private weak var dataTaskSource: SessionDataTaskDataSource?
+    
     // MARK: Intialization
     
     /**
@@ -64,24 +68,70 @@ public final class ServiceTask {
      - parameter dataTaskSource: Object responsible for creating a 
       NSURLSessionDataTask used to send the NSURLRequset.
     */
-    init(urlRequestEncodable: URLRequestEncodable, dataTaskSource: SessionDataTaskDataSource) {
+    
+    init(request: Request, dataTaskSource: SessionDataTaskDataSource) {
+        self.request = request
+        self.dataTaskSource = dataTaskSource
         self.handlerQueue = {
             let queue = dispatch_queue_create(("com.THGWebService.ServiceTask" as NSString).UTF8String, DISPATCH_QUEUE_SERIAL)
             dispatch_suspend(queue)
             return queue
         }()
-
-        self.dataTask = dataTaskSource.dataTaskWithRequest(urlRequestEncodable.urlRequestValue, completion: dataTaskCompletionHandler())
     }
 }
+
+// MARK: - Request API
+
+extension ServiceTask {
+    public func setParameters(parameters: [String: AnyObject], encoding: Request.ParameterEncoding? = nil) -> Self {
+        request.parameters = parameters
+        request.parameterEncoding = encoding ?? .Percent
+        return self
+    }
+        
+    public func setBody(data: NSData) -> Self {
+        request.body = data
+        return self
+    }
+    
+    public func setJSON(json: AnyObject) -> Self {
+        request.body = try? NSJSONSerialization.dataWithJSONObject(json, options: NSJSONWritingOptions(rawValue: 0))
+        return self
+    }
+    
+    public func setHeaders(headers: [String: String]) -> Self {
+        request.headers = headers
+        return self
+    }
+    
+    public func setHeaderValue(value: String, forName name: String) -> Self {
+        request.headers[name] = value
+        return self
+    }
+    
+    public func setCachePolicy(cachePolicy: NSURLRequestCachePolicy) -> Self {
+        request.cachePolicy = cachePolicy
+        return self
+    }
+    
+    public func setParameterEncoding(encoding: Request.ParameterEncoding) -> Self {
+        request.parameterEncoding = encoding
+        return self
+    }
+}
+
 
 // MARK: NSURLSesssionDataTask
 
 extension ServiceTask {
-    
     /// Resume the underlying data task.
-    public func resume() {
+    public func resume() -> Self {
+        if dataTask == nil {
+            dataTask = dataTaskSource?.dataTaskWithRequest(request.urlRequestValue, completion: dataTaskCompletionHandler())
+        }
+        
         dataTask?.resume()
+        return self
     }
     
     /// Suspend the underlying data task.

--- a/Source/Core/SessionDataTaskDataSource.swift
+++ b/Source/Core/SessionDataTaskDataSource.swift
@@ -1,0 +1,22 @@
+//
+//  SessionDataTaskDataSource.swift
+//  THGWebService
+//
+//  Created by Angelo Di Paolo on 11/3/15.
+//  Copyright © 2015 TheHolyGrail. All rights reserved.
+//
+
+import Foundation
+
+/**
+ Types conforming to the `SessionDataTaskDataSource` protocol are responsible
+ for creating `NSURLSessionDataTask` objects based on a `NSURLRequest` value
+ and invoking a completion handler after the response of a data task has been
+ received. Adopt this protocol in order to specify the `NSURLSession` instance
+ used to send requests.
+ */
+public protocol SessionDataTaskDataSource: class {
+    func dataTaskWithRequest(request: NSURLRequest, completionHandler: (NSData?, NSURLResponse?, NSError?) -> Void) -> NSURLSessionDataTask
+}
+
+extension NSURLSession: SessionDataTaskDataSource {}

--- a/Source/Core/WebService.swift
+++ b/Source/Core/WebService.swift
@@ -9,17 +9,6 @@
 import Foundation
 
 /**
-  Types conforming to the `SessionDataTaskDataSource` protocol are responsible 
-  for creating `NSURLSessionDataTask` objects based on a `NSURLRequest` value 
-  and invoking a completion handler after the response of a data task has been 
-  received. Adopt this protocol in order to specify the `NSURLSession` instance 
-  used to send requests.
-*/
-public protocol SessionDataTaskDataSource: class {
-    func dataTaskWithRequest(request: NSURLRequest, completion: (NSData?, NSURLResponse?, NSError?) -> Void) -> NSURLSessionDataTask?
-}
-
-/**
  A `WebService` value provides a concise API for encoding a NSURLRequest object
  and processing the resulting `NSURLResponse` object.
 */
@@ -32,6 +21,14 @@ public final class WebService {
      `NSURLRequest`.
     */
     public var dataTaskSource: SessionDataTaskDataSource?
+    
+    private var serviceDataTaskSource: SessionDataTaskDataSource {
+        if let dataTaskSource = dataTaskSource {
+            return dataTaskSource
+        } else {
+            return NSURLSession.sharedSession()
+        }
+    }
     
     // MARK: Initialization
     
@@ -165,25 +162,5 @@ extension WebService {
     func constructURLString(string: String, relativeToURLString relativeURLString: String) -> String {
         let relativeURL = NSURL(string: relativeURLString)
         return NSURL(string: string, relativeToURL: relativeURL)!.absoluteString
-    }
-}
-
-// MARK: - SessionDataTaskDataSource
-
-extension WebService: SessionDataTaskDataSource {
-    var serviceDataTaskSource: SessionDataTaskDataSource {
-        if let dataTaskSource = dataTaskSource {
-            return dataTaskSource
-        } else {
-            return self
-        }
-    }
-    
-    public func dataTaskWithRequest(request: NSURLRequest, completion: (NSData?, NSURLResponse?, NSError?) -> Void) -> NSURLSessionDataTask? {
-        if let task = dataTaskSource?.dataTaskWithRequest(request, completion: completion) {
-            return task
-        } else {
-            return NSURLSession.sharedSession().dataTaskWithRequest(request, completionHandler: completion);
-        }
     }
 }

--- a/Source/Core/WebService.swift
+++ b/Source/Core/WebService.swift
@@ -15,7 +15,7 @@ import Foundation
   received. Adopt this protocol in order to specify the `NSURLSession` instance 
   used to send requests.
 */
-public protocol SessionDataTaskDataSource {
+public protocol SessionDataTaskDataSource: class {
     func dataTaskWithRequest(request: NSURLRequest, completion: (NSData?, NSURLResponse?, NSError?) -> Void) -> NSURLSessionDataTask?
 }
 
@@ -28,16 +28,10 @@ public final class WebService {
     public let baseURLString: String
     
     /**
-     Set to `false` to prevent `ServiceTask` instances from resuming 
-     immediately.
-    */
-    public var startTasksImmediately = true
-    
-    /**
      Type responsible for creating a `NSURLSessionDataTask` based on a
      `NSURLRequest`.
     */
-    public var dataTaskSource: SessionDataTaskDataSource = DataTaskDataSource()
+    public var dataTaskSource: SessionDataTaskDataSource?
     
     // MARK: Initialization
     
@@ -62,13 +56,12 @@ extension WebService {
     a query string for `GET` requests.
     - parameter options: Endpoint options used to configure the HTTP request.
     - returns: A ServiceTask instance that refers to the lifetime of processing
-    a given request. The newly created task is resumed immediately if the
-    `startTasksImmediately` poperty is set to `true`.
+    a given request.
     */
-    public func GET(path: String, parameters: [String : AnyObject]? = nil, options: [Request.Option]? = nil) -> ServiceTask {
-        return request(.GET, path: path, parameters: parameters, options: options)
+    public func GET(path: String) -> ServiceTask {
+        return request(.GET, path: path)
     }
-    
+
     /**
     Create a service task for a `POST` HTTP request.
     
@@ -78,11 +71,10 @@ extension WebService {
     is set as the HTTP body for `POST` requests.
     - parameter options: Endpoint options used to configure the HTTP request.
     - returns: A ServiceTask instance that refers to the lifetime of processing
-    a given request. The newly created task is resumed immediately if the
-    `startTasksImmediately` poperty is set to `true`.
+    a given request.
     */
-    public func POST(path: String, parameters: [String : AnyObject]? = nil, options: [Request.Option]? = nil) -> ServiceTask {
-        return request(.POST, path: path, parameters: parameters, options: options)
+    public func POST(path: String) -> ServiceTask {
+        return request(.POST, path: path)
     }
     
     /**
@@ -94,11 +86,10 @@ extension WebService {
     is set as the HTTP body for `PUT` requests.
     - parameter options: Endpoint options used to configure the HTTP request.
     - returns: A ServiceTask instance that refers to the lifetime of processing
-    a given request. The newly created task is resumed immediately if the
-    `startTasksImmediately` poperty is set to `true`.
+    a given request.
     */
-    public func PUT(path: String, parameters: [String : AnyObject]? = nil, options: [Request.Option]? = nil) -> ServiceTask {
-        return request(.PUT, path: path, parameters: parameters, options: options)
+    public func PUT(path: String) -> ServiceTask {
+        return request(.PUT, path: path)
     }
     
     /**
@@ -110,11 +101,10 @@ extension WebService {
     is set as the HTTP body for `DELETE` requests.
     - parameter options: Endpoint options used to configure the HTTP request.
     - returns: A ServiceTask instance that refers to the lifetime of processing
-    a given request. The newly created task is resumed immediately if the
-    `startTasksImmediately` poperty is set to `true`.
+    a given request.
     */
-    public func DELETE(path: String, parameters: [String : AnyObject]? = nil, options: [Request.Option]? = nil) -> ServiceTask {
-        return request(.DELETE, path: path, parameters: parameters, options: options)
+    public func DELETE(path: String) -> ServiceTask {
+        return request(.DELETE, path: path)
     }
     
     /**
@@ -126,50 +116,14 @@ extension WebService {
     a query string for `HEAD` requests.
     - parameter options: Endpoint options used to configure the HTTP request.
     - returns: A ServiceTask instance that refers to the lifetime of processing
-    a given request. The newly created task is resumed immediately if the
-    `startTasksImmediately` poperty is set to `true`.
+    a given request.
     */
-    public func HEAD(path: String, parameters: [String : AnyObject]? = nil, options: [Request.Option]? = nil) -> ServiceTask {
-        return request(.HEAD, path: path, parameters: parameters, options: options)
+    public func HEAD(path: String) -> ServiceTask {
+        return request(.HEAD, path: path)
     }
 }
 
-// MARK: - RequestEncoder
-
-extension WebService: RequestEncoder {
-    /// Encode a Request value
-    func encodeRequest(method: Request.Method, url: String, parameters: [String : AnyObject]?, options: [Request.Option]?) -> Request {
-        var request = Request(method, url: url)
-        
-        if let parameters = parameters {
-            request.parameters = parameters
-        }
-        
-        if let options = options {
-            request = request.encodeOptions(options)
-        }
-        
-        return request
-    }
-    
-    /**
-    Create a `ServiceTask`
-    
-    - parameter urlRequestEncoder: Type that provides the encoded NSURLRequest value.
-    - returns: A ServiceTask instance that refers to the lifetime of processing
-    a given request. The newly created task is resumed immediately if the
-    `startTasksImmediately` poperty is set to `true`.
-    */
-    func serviceTask(urlRequestEncodable urlRequestEncodable: URLRequestEncodable) -> ServiceTask {
-        let task = ServiceTask(urlRequestEncodable: urlRequestEncodable, dataTaskSource: dataTaskSource)
-        
-        if startTasksImmediately {
-            task.resume()
-        }
-        
-        return task
-    }
-    
+extension WebService {
     /**
     Create a service task to fulfill a service request. By default the service
     task is started by calling resume(). To prevent service tasks from
@@ -179,15 +133,12 @@ extension WebService: RequestEncoder {
     - parameter method: HTTP request method.
     - parameter path: Request path. The value can be relative to the base URL string
     or absolute.
-    - parameter parameters: Optional request parameters.
-    - parameter options: Optional endpoint options used to configure the HTTP request.
     - returns: A ServiceTask instance that refers to the lifetime of processing
-    a given request. The newly created task is resumed immediately if the
-    `startTasksImmediately` poperty is set to `true`.
+    a given request.
     */
-    func request(method: Request.Method, path: String, parameters: [String : AnyObject]? = nil, options: [Request.Option]? = nil) -> ServiceTask {
-        let request = encodeRequest(method, url: absoluteURLString(path), parameters: parameters, options: options)
-        return serviceTask(urlRequestEncodable: request)
+    func request(method: Request.Method, path: String) -> ServiceTask {
+        let request = Request(method, url: absoluteURLString(path))
+        return ServiceTask(request: request, dataTaskSource: serviceDataTaskSource)
     }
 }
 
@@ -219,8 +170,20 @@ extension WebService {
 
 // MARK: - SessionDataTaskDataSource
 
-struct DataTaskDataSource: SessionDataTaskDataSource {
-    func dataTaskWithRequest(request: NSURLRequest, completion: (NSData?, NSURLResponse?, NSError?) -> Void) -> NSURLSessionDataTask? {
-        return NSURLSession.sharedSession().dataTaskWithRequest(request, completionHandler: completion);
+extension WebService: SessionDataTaskDataSource {
+    var serviceDataTaskSource: SessionDataTaskDataSource {
+        if let dataTaskSource = dataTaskSource {
+            return dataTaskSource
+        } else {
+            return self
+        }
+    }
+    
+    public func dataTaskWithRequest(request: NSURLRequest, completion: (NSData?, NSURLResponse?, NSError?) -> Void) -> NSURLSessionDataTask? {
+        if let task = dataTaskSource?.dataTaskWithRequest(request, completion: completion) {
+            return task
+        } else {
+            return NSURLSession.sharedSession().dataTaskWithRequest(request, completionHandler: completion);
+        }
     }
 }

--- a/THGWebService.xcodeproj/project.pbxproj
+++ b/THGWebService.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		17D1E56E1AD5538000384D2D /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D1E56B1AD5538000384D2D /* Request.swift */; };
 		17D1E56F1AD5538000384D2D /* ServiceTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D1E56C1AD5538000384D2D /* ServiceTask.swift */; };
 		17D1E5701AD5538000384D2D /* WebService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D1E56D1AD5538000384D2D /* WebService.swift */; };
+		17E34E021BE994FB0068866A /* SessionDataTaskDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E34E011BE994FB0068866A /* SessionDataTaskDataSource.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,6 +54,7 @@
 		17D1E56B1AD5538000384D2D /* Request.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
 		17D1E56C1AD5538000384D2D /* ServiceTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServiceTask.swift; sourceTree = "<group>"; };
 		17D1E56D1AD5538000384D2D /* WebService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebService.swift; sourceTree = "<group>"; };
+		17E34E011BE994FB0068866A /* SessionDataTaskDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionDataTaskDataSource.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -136,6 +138,7 @@
 				17D1E56B1AD5538000384D2D /* Request.swift */,
 				17D1E56C1AD5538000384D2D /* ServiceTask.swift */,
 				17D1E56D1AD5538000384D2D /* WebService.swift */,
+				17E34E011BE994FB0068866A /* SessionDataTaskDataSource.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -252,6 +255,7 @@
 			files = (
 				17D1E5701AD5538000384D2D /* WebService.swift in Sources */,
 				17D1E56F1AD5538000384D2D /* ServiceTask.swift in Sources */,
+				17E34E021BE994FB0068866A /* SessionDataTaskDataSource.swift in Sources */,
 				17D1E56E1AD5538000384D2D /* Request.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/THGWebServiceTests/WebServiceTests.swift
+++ b/THGWebServiceTests/WebServiceTests.swift
@@ -334,34 +334,5 @@ class WebServiceTests: XCTestCase {
         
         waitForExpectationsWithTimeout(2, handler: nil)
     }
-    
-    func testFoo() {
-        let service = WebService(baseURLString: baseURL)
-        let successExpectation = expectationWithDescription("Received status 200")
-
-        service
-            .POST("/post")
-                .setHeaderValue("Custom-Header", forName: "bar")
-                .setParameters(["foo" : "this needs percent encoded"])
-            .response { data, res in
-                let httpResponse = res as! NSHTTPURLResponse
-                
-                if httpResponse.statusCode == 200 {
-                    successExpectation.fulfill()
-                }
-            }
-            .resume()
-        
-        waitForExpectationsWithTimeout(5.0, handler: nil)
-        
-        /**
-        
-        POST /stores HTTP/1.1
-        Custom-Header: bar
-        Content-Length: 55
-        
-        foo=this%20needs%20percent%20encoded
-        */
-    }
 }
 

--- a/THGWebServiceTests/WebServiceTests.swift
+++ b/THGWebServiceTests/WebServiceTests.swift
@@ -49,7 +49,8 @@ class WebServiceTests: XCTestCase {
         let task = service
                     .GET("/get")
                     .response(handler)
-        
+                    .resume()
+
         XCTAssertEqual(task.state, NSURLSessionTaskState.Running, "Task should be running by default")
         waitForExpectationsWithTimeout(2, handler: nil)
     }
@@ -68,7 +69,8 @@ class WebServiceTests: XCTestCase {
         let task = service
             .GET("http://httpbin.org/get")
             .response(handler)
-        
+            .resume()
+
         XCTAssertEqual(task.state, NSURLSessionTaskState.Running, "Task should be running by default")
         waitForExpectationsWithTimeout(2, handler: nil)
     }
@@ -80,6 +82,7 @@ class WebServiceTests: XCTestCase {
         let task = service
             .POST("/post")
             .response(handler)
+            .resume()
         
         XCTAssertEqual(task.state, NSURLSessionTaskState.Running, "Task should be running by default")
         waitForExpectationsWithTimeout(2, handler: nil)
@@ -92,7 +95,8 @@ class WebServiceTests: XCTestCase {
         let task = service
             .PUT("/put")
             .response(handler)
-        
+            .resume()
+
         XCTAssertEqual(task.state, NSURLSessionTaskState.Running, "Task should be running by default")
         waitForExpectationsWithTimeout(2, handler: nil)
     }
@@ -104,20 +108,10 @@ class WebServiceTests: XCTestCase {
         let task = service
             .DELETE("/delete")
             .response(handler)
+            .resume()
         
         XCTAssertEqual(task.state, NSURLSessionTaskState.Running, "Task should be running by default")
         waitForExpectationsWithTimeout(2, handler: nil)
-    }
-    
-    func testDisableStartTasksImmediately() {
-        let baseURL = "http://httpbin.org/"
-        
-        var service = WebService(baseURLString: baseURL)
-        service.startTasksImmediately = false
-        
-        let task = service.GET("/get")
-
-        XCTAssertEqual(task.state, NSURLSessionTaskState.Suspended, "Task should be suspended when startTasksImmediately is disabled")
     }
 
     func testErrorHandler() {
@@ -134,7 +128,8 @@ class WebServiceTests: XCTestCase {
                 XCTAssertFalse(wasResponseCalled, "Response should not be called for error cases")
                 errorExpectation.fulfill()
             }
-        
+            .resume()
+
         waitForExpectationsWithTimeout(2, handler: nil)
     }
     
@@ -151,7 +146,8 @@ class WebServiceTests: XCTestCase {
             }
             .response { data, response in
                 successExpectation.fulfill()
-        }
+            }
+            .resume()
         
         XCTAssertEqual(task.state, NSURLSessionTaskState.Running, "Task should be running by default")
         waitForExpectationsWithTimeout(4, handler: nil)
@@ -164,7 +160,8 @@ class WebServiceTests: XCTestCase {
         let task = service
             .GET("/get")
             .responseJSON(handler)
-        
+            .resume()
+
         XCTAssertEqual(task.state, NSURLSessionTaskState.Running, "Task should be running by default")
         waitForExpectationsWithTimeout(2, handler: nil)
     }
@@ -177,7 +174,8 @@ class WebServiceTests: XCTestCase {
         let task = service
             .GET("/get")
             .responseJSON(queue, handler: handler)
-        
+            .resume()
+
         XCTAssertEqual(task.state, NSURLSessionTaskState.Running, "Task should be running by default")
         waitForExpectationsWithTimeout(2, handler: nil)
     }
@@ -188,7 +186,8 @@ class WebServiceTests: XCTestCase {
         let parameters = ["foo" : "bar", "percentEncoded" : "this needs percent encoded"]
         
         service
-            .GET("/get", parameters: parameters)
+            .GET("/get")
+                .setParameters(parameters)
             .response { data, response in
                 
                 let httpResponse = response as! NSHTTPURLResponse
@@ -206,7 +205,8 @@ class WebServiceTests: XCTestCase {
                 
                 RequestTests.assertRequestParametersNotEqual(deliveredParameters!, toOriginalParameters: parameters)
             }
-        
+            .resume()
+
         waitForExpectationsWithTimeout(2, handler: nil)
     }
     
@@ -216,7 +216,8 @@ class WebServiceTests: XCTestCase {
         let parameters = ["foo" : "bar", "percentEncoded" : "this needs percent encoded"]
         
         service
-            .POST("/post", parameters: parameters)
+            .POST("/post")
+                .setParameters(parameters)
             .response { data, response in
                 
                 let httpResponse = response as! NSHTTPURLResponse
@@ -233,8 +234,9 @@ class WebServiceTests: XCTestCase {
                 XCTAssert(deliveredParameters != nil)
                 
                 RequestTests.assertRequestParametersNotEqual(deliveredParameters!, toOriginalParameters: parameters)
-        }
-        
+            }
+            .resume()
+
         waitForExpectationsWithTimeout(2, handler: nil)
     }
     
@@ -244,9 +246,8 @@ class WebServiceTests: XCTestCase {
         let parameters = ["foo" : "bar", "number" : 42]
         
         service
-            .POST("/post",
-                parameters: parameters,
-                options: [.ParameterEncoding(.JSON)])
+            .POST("/post")
+                .setParameters(parameters, encoding: .JSON)
             .response { data, response in
                 
                 let httpResponse = response as! NSHTTPURLResponse
@@ -263,7 +264,8 @@ class WebServiceTests: XCTestCase {
                 XCTAssert(deliveredParameters != nil)
                 
                 RequestTests.assertRequestParametersNotEqual(deliveredParameters!, toOriginalParameters: parameters)
-        }
+            }
+            .resume()
         
         waitForExpectationsWithTimeout(2, handler: nil)
     }
@@ -276,12 +278,9 @@ class WebServiceTests: XCTestCase {
         let jsonArray = [jsonObject, jsonObject]
         
         service
-            .POST("/post",
-                parameters: nil,
-                options: [
-                    .ParameterEncoding(.JSON),
-                    .BodyJSON(jsonArray)
-                ])
+            .POST("/post")
+                .setParameterEncoding(.JSON)
+                .setJSON(jsonArray)
             .response { data, response in
                 
                 let httpResponse = response as! NSHTTPURLResponse
@@ -300,7 +299,8 @@ class WebServiceTests: XCTestCase {
                 for deliveredJSONObject in deliveredArray! {
                     RequestTests.assertRequestParametersNotEqual(deliveredJSONObject, toOriginalParameters: jsonObject)
                 }
-        }
+            }
+            .resume()
         
         waitForExpectationsWithTimeout(2, handler: nil)
     }
@@ -308,12 +308,11 @@ class WebServiceTests: XCTestCase {
     func testHeadersDelivered() {
         let successExpectation = expectationWithDescription("Received status 200")
         let service = WebService(baseURLString: baseURL)
-        let headers = ["Some-Test-Header" :"testValue"]
+        let headers =  ["Some-Test-Header" :"testValue"]
         
         service
-            .GET("/get",
-                parameters: nil,
-                options: [.Header("Some-Test-Header", "testValue")])
+            .GET("/get")
+                .setHeaders(headers)
             .response { data, response in
                 
                 let httpResponse = response as! NSHTTPURLResponse
@@ -330,9 +329,39 @@ class WebServiceTests: XCTestCase {
                 XCTAssert(deliveredHeaders != nil)
                 
                 RequestTests.assertRequestParametersNotEqual(deliveredHeaders!, toOriginalParameters: headers)
-        }
+            }
+            .resume()
         
         waitForExpectationsWithTimeout(2, handler: nil)
+    }
+    
+    func testFoo() {
+        let service = WebService(baseURLString: baseURL)
+        let successExpectation = expectationWithDescription("Received status 200")
+
+        service
+            .POST("/post")
+                .setHeaderValue("Custom-Header", forName: "bar")
+                .setParameters(["foo" : "this needs percent encoded"])
+            .response { data, res in
+                let httpResponse = res as! NSHTTPURLResponse
+                
+                if httpResponse.statusCode == 200 {
+                    successExpectation.fulfill()
+                }
+            }
+            .resume()
+        
+        waitForExpectationsWithTimeout(5.0, handler: nil)
+        
+        /**
+        
+        POST /stores HTTP/1.1
+        Custom-Header: bar
+        Content-Length: 55
+        
+        foo=this%20needs%20percent%20encoded
+        */
     }
 }
 


### PR DESCRIPTION
## summary

- remove [request option API](https://github.com/TheHolyGrail/Swallow/commit/61fff95fc3c6bf340a8f25c75568b4a426b2bbe2#diff-ccdf9c56c88fdfd8d8c9f51eaa59a280L206)
- add [`ServiceTask`  methods](https://github.com/TheHolyGrail/Swallow/compare/request-option-api?expand=1#diff-0dbabe1bcb21e58eed224610cdb2bb40R85) for configuring the Request value
- remove `startTasksImmediately` from `WebService`

## details

This is a work in progress of a cleaner API for configuring request details to address issue #9.

### new request option API

The request option API was removed in favor of adding chainable methods to `ServiceTask` for configuring the HTTP request.


The old syntax:

```
service
    .POST("/post", 
        parameters: ["foo" : "this needs percent encoded"],
        options: [
            .Header("Custom-Header", forName: "bar")
        ])
      .response { data, res in
            // process response
        }
```

The new syntax:

```
service
    .POST("/post")
        .setHeaderValue("bar", forName: "Custom-Header")
        .setParameters(["foo" : "this needs percent encoded"])
    .response { data, res in
        // process response
    }
    .resume()
```

Produces the HTTP request:

```
POST /post HTTP/1.1
Host: httpbin.org
Content-Type: application/x-www-form-urlencoded
Accept: */*
Connection: keep-alive
Custom-Header: bar
Accept-Language: en-us
Content-Length: 36
Accept-Encoding: gzip, deflate
User-Agent: xctest (unknown version) CFNetwork/758.0.2 Darwin/15.0.0

foo=this%20needs%20percent%20encoded
```

### resume()

Previously `ServiceTask` instances were being resumed immediately after being initialized as a result of `WebService`'s `startTasksImmediately` property being set to `true` by default. Now that `ServiceTask` is also being used to chain request configuration details I think it is better to be explicit about when the `NSURLSessionDataTask` is being resumed. 

This change means that all service calls will require `resume()` to be called at the end of the chain.


## outstanding

- ~~[`testErrorHandler` unit test](https://travis-ci.org/TheHolyGrail/Swallow/builds/85456233#L256) is failing~~
- updated readme
- updated programming guide

