### PR TITLE
run response handlers on bg queue

### DIFF
--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -19,10 +19,6 @@ protocol URLRequestEncodable {
     var urlRequestValue: NSURLRequest {get}
 }
 
-protocol RequestEncoder {
-    func encodeRequest(method: Request.Method, url: String, parameters: [String : AnyObject]?, options: [Request.Option]?) -> Request
-}
-
 /**
  Encapsulates the data required to send an HTTP request.
 */
@@ -97,7 +93,7 @@ public struct Request {
         public static let formEncoded = "application/x-www-form-urlencoded"
         public static let json = "application/json"
     }
-    
+        
     /// The HTTP method of the request.
     public let method: Method
     
@@ -198,52 +194,6 @@ extension Request: URLRequestEncodable {
         }
 
         return urlRequest.copy() as! NSURLRequest
-    }
-}
-
-// MARK: - Request Options
-
-extension Request {
-    
-    /// An `Option` value defines a rule for encoding part of a `Request` value.
-    public enum Option {
-        /// Defines the parameter encoding for the HTTP request.
-        case ParameterEncoding(Request.ParameterEncoding)
-        /// Defines a HTTP header field name and value to set in the `Request`.
-        case Header(String, String)
-        /// Defines the cache policy to set in the `Request` value.
-        case CachePolicy(NSURLRequestCachePolicy)
-        /// Defines the HTTP body contents of the HTTP request.
-        case Body(NSData)
-        /// Defines the JSON object that will be serialized as the body of the HTTP request.
-        case BodyJSON(AnyObject)
-    }
-    
-    /// Uses an array of `Option` values as rules for mutating a `Request` value.
-    func encodeOptions(options: [Option]) -> Request {
-        var request = self
-        
-        for option in options {
-            switch option {
-                
-            case .ParameterEncoding(let encoding):
-                request.parameterEncoding = encoding
-                
-            case .Header(let name, let value):
-                request.headers[name] = value
-                
-            case .CachePolicy(let cachePolicy):
-                request.cachePolicy = cachePolicy
-                
-            case .Body(let data):
-                request.body = data
-                
-            case .BodyJSON(let json):
-                request.body = try? NSJSONSerialization.dataWithJSONObject(json, options: NSJSONWritingOptions(rawValue: 0))
-            }
-        }
-        
-        return request
     }
 }
 

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -127,7 +127,7 @@ extension ServiceTask {
     /// Resume the underlying data task.
     public func resume() -> Self {
         if dataTask == nil {
-            dataTask = dataTaskSource?.dataTaskWithRequest(request.urlRequestValue, completion: dataTaskCompletionHandler())
+            dataTask = dataTaskSource?.dataTaskWithRequest(request.urlRequestValue, completionHandler: dataTaskCompletionHandler())
         }
         
         dataTask?.resume()

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /**
- A lightweight wrapper around `NSURLSessionDataTask` that provides a chainable 
+ A lightweight wrapper around `NSURLSessionDataTask` that provides a chainable
  API for processing the result of a data task. A `ServiceTask` instance can be
  cancelled and suspended like a data task as well as queried for current state
  via the `state` property.
@@ -17,24 +17,11 @@ import Foundation
 public final class ServiceTask {
     private var request: Request
     
-    /// Represents the result of a service task.
-    private enum Result {
-        case Success(NSData?, NSURLResponse?)
-        case Failure(ErrorType)
-        
-        init(data: NSData?, response: NSURLResponse?, error: NSError?) {
-            if let error = error {
-                self = .Failure(error)
-            } else {
-                self = .Success(data, response)
-            }
-            
-        }
-    }
+    public typealias ResponseProcessingHandler = (NSData?, NSURLResponse?) -> ServiceTaskResult
     
     /// A closure type alias for a success handler.
-    public typealias SuccessHandler = (NSData?, NSURLResponse?) -> Void
-    
+    public typealias UpdateUIHandler = (AnyObject?) -> Void
+
     /// A closure type alias for an error handler.
     public typealias ErrorHandler = (ErrorType) -> Void
     
@@ -54,7 +41,13 @@ public final class ServiceTask {
     private var dataTask: NSURLSessionDataTask?
     
     /// Result of the service task
-    private var result: Result?
+    private var taskResult: ServiceTaskResult?
+    
+    /// Response body data
+    private var responseData: NSData?
+    
+    /// URL response
+    private var urlResponse: NSURLResponse?
     
     private weak var dataTaskSource: SessionDataTaskDataSource?
     
@@ -146,7 +139,13 @@ extension ServiceTask {
     
     private func dataTaskCompletionHandler() -> (NSData?, NSURLResponse?, NSError?) -> Void {
         return { data, response, error in
-            self.result = Result(data: data, response: response, error: error)
+            self.urlResponse = response
+            self.responseData = data
+            
+            if let error = error {
+                self.taskResult = ServiceTaskResult.Failure(error)
+            }
+            
             dispatch_resume(self.handlerQueue)
         }
     }
@@ -162,29 +161,35 @@ extension ServiceTask {
     - parameter handler: Response handler to execute upon receiving a response.
     - returns: Self instance to support chaining.
     */
-    public func response(handler: SuccessHandler) -> Self {
-        return response(dispatch_get_main_queue(), handler: handler)
+    public func response(handler: ResponseProcessingHandler) -> Self {
+        dispatch_async(handlerQueue) {
+            if let taskResult = self.taskResult {
+                switch taskResult {
+                case .Failure(_): return // bail out to avoid next handler from running
+                case .Value(_): break
+                case .Empty: break
+                }
+            }
+            
+            self.taskResult = handler(self.responseData, self.urlResponse)
+        }
+
+        return self
     }
     
-    /**
-    Add a response handler to be called once a successful response has been
-    received.
-    
-    - parameter queue: The target dispatch queue to which the response handler
-    is submitted.
-    - parameter handler: Response handler to execute upon receiving a response.
-    - returns: Self instance to support chaining.
-    */
-    public func response(queue: dispatch_queue_t, handler: SuccessHandler) -> Self {
+    public func updateUI(handler: UpdateUIHandler) -> Self {
         dispatch_async(handlerQueue) {
-            dispatch_async(queue) {
-                if let result = self.result {
-                    switch result {
-                    case .Success(let data, let response):
-                        handler(data, response)
-                    default:
-                        break
+            if let taskResult = self.taskResult {
+                switch taskResult {
+                case .Value(let value):
+                    dispatch_async(dispatch_get_main_queue()) {
+                        handler(value)
                     }
+                case .Empty:
+                    dispatch_async(dispatch_get_main_queue()) {
+                        handler(nil)
+                    }
+                case .Failure(_): break
                 }
             }
         }
@@ -193,11 +198,12 @@ extension ServiceTask {
     }
 }
 
+
 // MARK: - JSON
 
 extension ServiceTask {
     /// A closure type alias for handling the response as JSON.
-    public typealias JSONHandler = (AnyObject) -> Void
+    public typealias JSONHandler = (AnyObject) -> ServiceTaskResult
     
     /**
      Add a response handler to serialize the response body as a JSON object. The
@@ -207,27 +213,18 @@ extension ServiceTask {
      - returns: Self instance to support chaining.
     */
     public func responseJSON(handler: JSONHandler) -> Self {
-        return responseJSON(dispatch_get_main_queue(), handler: handler)
-    }
-    
-    /**
-     Add a response handler to serialize the response body as a JSON object.
-    
-     - parameter queue: The DispatchQueue used to dispatch the response handler.
-     - parameter handler: Response handler to execute upon receiving a response.
-     - returns: Self instance to support chaining.
-    */
-    public func responseJSON(queue: dispatch_queue_t, handler: JSONHandler) -> Self {
-        return response(queue) { data, response in
+        return response { data, response in
             if let data = data {
                 do {
                     let json = try NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions.AllowFragments)
-                    handler(json)
+                    return handler(json)
                 } catch let jsonError as NSError {
-                    self.throwError(jsonError)
+                    return .Failure(jsonError)
                 } catch {
                     fatalError()
                 }
+            } else {
+                return .Failure(ServiceTaskError.JSONSerializationFailedNilResponseBody)
             }
         }
     }
@@ -244,16 +241,16 @@ extension ServiceTask {
     */
     public func responseError(handler: ErrorHandler) -> Self {
         dispatch_async(handlerQueue) {
-            dispatch_async(dispatch_get_main_queue()) {
-                if let result = self.result {
-                    switch result {
-                    case .Failure(let error):
+            
+            if let taskResult = self.taskResult {
+                switch taskResult {
+                case .Failure(let error):
+                    dispatch_async(dispatch_get_main_queue()) {
                         handler(error)
-                    default:
-                        break
                     }
+                case .Value(_): break
+                case .Empty: break
                 }
-                
             }
         }
         
@@ -264,7 +261,11 @@ extension ServiceTask {
      Call to indicate that an error occured during the processing of a response.
      Causes responseError handlers to be called.
     */
-    public func throwError(error: ErrorType) {
-        self.result = .Failure(error)
-    }
+//    public func throwError(error: ErrorType) {
+//        self.result = .Failure(error)
+//    }
+}
+
+public enum ServiceTaskError: ErrorType {
+    case JSONSerializationFailedNilResponseBody
 }

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -15,6 +15,8 @@ import Foundation
  via the `state` property.
 */
 public final class ServiceTask {
+    private var request: Request
+    
     /// Represents the result of a service task.
     private enum Result {
         case Success(NSData?, NSURLResponse?)
@@ -54,6 +56,8 @@ public final class ServiceTask {
     /// Result of the service task
     private var result: Result?
     
+    private weak var dataTaskSource: SessionDataTaskDataSource?
+    
     // MARK: Intialization
     
     /**
@@ -64,24 +68,70 @@ public final class ServiceTask {
      - parameter dataTaskSource: Object responsible for creating a 
       NSURLSessionDataTask used to send the NSURLRequset.
     */
-    init(urlRequestEncodable: URLRequestEncodable, dataTaskSource: SessionDataTaskDataSource) {
+    
+    init(request: Request, dataTaskSource: SessionDataTaskDataSource) {
+        self.request = request
+        self.dataTaskSource = dataTaskSource
         self.handlerQueue = {
             let queue = dispatch_queue_create(("com.THGWebService.ServiceTask" as NSString).UTF8String, DISPATCH_QUEUE_SERIAL)
             dispatch_suspend(queue)
             return queue
         }()
-
-        self.dataTask = dataTaskSource.dataTaskWithRequest(urlRequestEncodable.urlRequestValue, completion: dataTaskCompletionHandler())
     }
 }
+
+// MARK: - Request API
+
+extension ServiceTask {
+    public func setParameters(parameters: [String: AnyObject], encoding: Request.ParameterEncoding? = nil) -> Self {
+        request.parameters = parameters
+        request.parameterEncoding = encoding ?? .Percent
+        return self
+    }
+        
+    public func setBody(data: NSData) -> Self {
+        request.body = data
+        return self
+    }
+    
+    public func setJSON(json: AnyObject) -> Self {
+        request.body = try? NSJSONSerialization.dataWithJSONObject(json, options: NSJSONWritingOptions(rawValue: 0))
+        return self
+    }
+    
+    public func setHeaders(headers: [String: String]) -> Self {
+        request.headers = headers
+        return self
+    }
+    
+    public func setHeaderValue(value: String, forName name: String) -> Self {
+        request.headers[name] = value
+        return self
+    }
+    
+    public func setCachePolicy(cachePolicy: NSURLRequestCachePolicy) -> Self {
+        request.cachePolicy = cachePolicy
+        return self
+    }
+    
+    public func setParameterEncoding(encoding: Request.ParameterEncoding) -> Self {
+        request.parameterEncoding = encoding
+        return self
+    }
+}
+
 
 // MARK: NSURLSesssionDataTask
 
 extension ServiceTask {
-    
     /// Resume the underlying data task.
-    public func resume() {
+    public func resume() -> Self {
+        if dataTask == nil {
+            dataTask = dataTaskSource?.dataTaskWithRequest(request.urlRequestValue, completion: dataTaskCompletionHandler())
+        }
+        
         dataTask?.resume()
+        return self
     }
     
     /// Suspend the underlying data task.

--- a/Source/Core/ServiceTask.swift
+++ b/Source/Core/ServiceTask.swift
@@ -241,7 +241,27 @@ extension ServiceTask {
     */
     public func responseError(handler: ErrorHandler) -> Self {
         dispatch_async(handlerQueue) {
-            
+            if let taskResult = self.taskResult {
+                switch taskResult {
+                case .Failure(let error): handler(error)
+                case .Value(_): break
+                case .Empty: break
+                }
+            }
+        }
+        
+        return self
+    }
+    
+    /**
+     Add a response handler to be called if a request results in an error. Handler
+     will be called on the main queue.
+     
+     :param: handler Error handler to execute when an error occurs.
+     :returns: Self instance to support chaining.
+     */
+    public func updateErrorUI(handler: ErrorHandler) -> Self {
+        dispatch_async(handlerQueue) {
             if let taskResult = self.taskResult {
                 switch taskResult {
                 case .Failure(let error):

--- a/Source/Core/ServiceTaskResult.swift
+++ b/Source/Core/ServiceTaskResult.swift
@@ -1,0 +1,19 @@
+//
+//  ServiceTaskResult.swift
+//  THGWebService
+//
+//  Created by Angelo Di Paolo on 11/5/15.
+//  Copyright © 2015 TheHolyGrail. All rights reserved.
+//
+
+import Foundation
+
+/// Represents the result of a service task.
+public enum ServiceTaskResult {
+    /// Defines an empty task result
+    case Empty
+    /// Defines a task result as a value
+    case Value(AnyObject)
+    /// Defines a task resulting in an error
+    case Failure(ErrorType)
+}

--- a/Source/Core/SessionDataTaskDataSource.swift
+++ b/Source/Core/SessionDataTaskDataSource.swift
@@ -1,0 +1,22 @@
+//
+//  SessionDataTaskDataSource.swift
+//  THGWebService
+//
+//  Created by Angelo Di Paolo on 11/3/15.
+//  Copyright © 2015 TheHolyGrail. All rights reserved.
+//
+
+import Foundation
+
+/**
+ Types conforming to the `SessionDataTaskDataSource` protocol are responsible
+ for creating `NSURLSessionDataTask` objects based on a `NSURLRequest` value
+ and invoking a completion handler after the response of a data task has been
+ received. Adopt this protocol in order to specify the `NSURLSession` instance
+ used to send requests.
+ */
+public protocol SessionDataTaskDataSource: class {
+    func dataTaskWithRequest(request: NSURLRequest, completionHandler: (NSData?, NSURLResponse?, NSError?) -> Void) -> NSURLSessionDataTask
+}
+
+extension NSURLSession: SessionDataTaskDataSource {}

--- a/Source/Core/WebService.swift
+++ b/Source/Core/WebService.swift
@@ -9,17 +9,6 @@
 import Foundation
 
 /**
-  Types conforming to the `SessionDataTaskDataSource` protocol are responsible 
-  for creating `NSURLSessionDataTask` objects based on a `NSURLRequest` value 
-  and invoking a completion handler after the response of a data task has been 
-  received. Adopt this protocol in order to specify the `NSURLSession` instance 
-  used to send requests.
-*/
-public protocol SessionDataTaskDataSource: class {
-    func dataTaskWithRequest(request: NSURLRequest, completion: (NSData?, NSURLResponse?, NSError?) -> Void) -> NSURLSessionDataTask?
-}
-
-/**
  A `WebService` value provides a concise API for encoding a NSURLRequest object
  and processing the resulting `NSURLResponse` object.
 */
@@ -32,6 +21,14 @@ public final class WebService {
      `NSURLRequest`.
     */
     public var dataTaskSource: SessionDataTaskDataSource?
+    
+    private var serviceDataTaskSource: SessionDataTaskDataSource {
+        if let dataTaskSource = dataTaskSource {
+            return dataTaskSource
+        } else {
+            return NSURLSession.sharedSession()
+        }
+    }
     
     // MARK: Initialization
     
@@ -165,25 +162,5 @@ extension WebService {
     func constructURLString(string: String, relativeToURLString relativeURLString: String) -> String {
         let relativeURL = NSURL(string: relativeURLString)
         return NSURL(string: string, relativeToURL: relativeURL)!.absoluteString
-    }
-}
-
-// MARK: - SessionDataTaskDataSource
-
-extension WebService: SessionDataTaskDataSource {
-    var serviceDataTaskSource: SessionDataTaskDataSource {
-        if let dataTaskSource = dataTaskSource {
-            return dataTaskSource
-        } else {
-            return self
-        }
-    }
-    
-    public func dataTaskWithRequest(request: NSURLRequest, completion: (NSData?, NSURLResponse?, NSError?) -> Void) -> NSURLSessionDataTask? {
-        if let task = dataTaskSource?.dataTaskWithRequest(request, completion: completion) {
-            return task
-        } else {
-            return NSURLSession.sharedSession().dataTaskWithRequest(request, completionHandler: completion);
-        }
     }
 }

--- a/Source/Core/WebService.swift
+++ b/Source/Core/WebService.swift
@@ -15,7 +15,7 @@ import Foundation
   received. Adopt this protocol in order to specify the `NSURLSession` instance 
   used to send requests.
 */
-public protocol SessionDataTaskDataSource {
+public protocol SessionDataTaskDataSource: class {
     func dataTaskWithRequest(request: NSURLRequest, completion: (NSData?, NSURLResponse?, NSError?) -> Void) -> NSURLSessionDataTask?
 }
 
@@ -28,16 +28,10 @@ public final class WebService {
     public let baseURLString: String
     
     /**
-     Set to `false` to prevent `ServiceTask` instances from resuming 
-     immediately.
-    */
-    public var startTasksImmediately = true
-    
-    /**
      Type responsible for creating a `NSURLSessionDataTask` based on a
      `NSURLRequest`.
     */
-    public var dataTaskSource: SessionDataTaskDataSource = DataTaskDataSource()
+    public var dataTaskSource: SessionDataTaskDataSource?
     
     // MARK: Initialization
     
@@ -62,13 +56,12 @@ extension WebService {
     a query string for `GET` requests.
     - parameter options: Endpoint options used to configure the HTTP request.
     - returns: A ServiceTask instance that refers to the lifetime of processing
-    a given request. The newly created task is resumed immediately if the
-    `startTasksImmediately` poperty is set to `true`.
+    a given request.
     */
-    public func GET(path: String, parameters: [String : AnyObject]? = nil, options: [Request.Option]? = nil) -> ServiceTask {
-        return request(.GET, path: path, parameters: parameters, options: options)
+    public func GET(path: String) -> ServiceTask {
+        return request(.GET, path: path)
     }
-    
+
     /**
     Create a service task for a `POST` HTTP request.
     
@@ -78,11 +71,10 @@ extension WebService {
     is set as the HTTP body for `POST` requests.
     - parameter options: Endpoint options used to configure the HTTP request.
     - returns: A ServiceTask instance that refers to the lifetime of processing
-    a given request. The newly created task is resumed immediately if the
-    `startTasksImmediately` poperty is set to `true`.
+    a given request.
     */
-    public func POST(path: String, parameters: [String : AnyObject]? = nil, options: [Request.Option]? = nil) -> ServiceTask {
-        return request(.POST, path: path, parameters: parameters, options: options)
+    public func POST(path: String) -> ServiceTask {
+        return request(.POST, path: path)
     }
     
     /**
@@ -94,11 +86,10 @@ extension WebService {
     is set as the HTTP body for `PUT` requests.
     - parameter options: Endpoint options used to configure the HTTP request.
     - returns: A ServiceTask instance that refers to the lifetime of processing
-    a given request. The newly created task is resumed immediately if the
-    `startTasksImmediately` poperty is set to `true`.
+    a given request.
     */
-    public func PUT(path: String, parameters: [String : AnyObject]? = nil, options: [Request.Option]? = nil) -> ServiceTask {
-        return request(.PUT, path: path, parameters: parameters, options: options)
+    public func PUT(path: String) -> ServiceTask {
+        return request(.PUT, path: path)
     }
     
     /**
@@ -110,11 +101,10 @@ extension WebService {
     is set as the HTTP body for `DELETE` requests.
     - parameter options: Endpoint options used to configure the HTTP request.
     - returns: A ServiceTask instance that refers to the lifetime of processing
-    a given request. The newly created task is resumed immediately if the
-    `startTasksImmediately` poperty is set to `true`.
+    a given request.
     */
-    public func DELETE(path: String, parameters: [String : AnyObject]? = nil, options: [Request.Option]? = nil) -> ServiceTask {
-        return request(.DELETE, path: path, parameters: parameters, options: options)
+    public func DELETE(path: String) -> ServiceTask {
+        return request(.DELETE, path: path)
     }
     
     /**
@@ -126,50 +116,14 @@ extension WebService {
     a query string for `HEAD` requests.
     - parameter options: Endpoint options used to configure the HTTP request.
     - returns: A ServiceTask instance that refers to the lifetime of processing
-    a given request. The newly created task is resumed immediately if the
-    `startTasksImmediately` poperty is set to `true`.
+    a given request.
     */
-    public func HEAD(path: String, parameters: [String : AnyObject]? = nil, options: [Request.Option]? = nil) -> ServiceTask {
-        return request(.HEAD, path: path, parameters: parameters, options: options)
+    public func HEAD(path: String) -> ServiceTask {
+        return request(.HEAD, path: path)
     }
 }
 
-// MARK: - RequestEncoder
-
-extension WebService: RequestEncoder {
-    /// Encode a Request value
-    func encodeRequest(method: Request.Method, url: String, parameters: [String : AnyObject]?, options: [Request.Option]?) -> Request {
-        var request = Request(method, url: url)
-        
-        if let parameters = parameters {
-            request.parameters = parameters
-        }
-        
-        if let options = options {
-            request = request.encodeOptions(options)
-        }
-        
-        return request
-    }
-    
-    /**
-    Create a `ServiceTask`
-    
-    - parameter urlRequestEncoder: Type that provides the encoded NSURLRequest value.
-    - returns: A ServiceTask instance that refers to the lifetime of processing
-    a given request. The newly created task is resumed immediately if the
-    `startTasksImmediately` poperty is set to `true`.
-    */
-    func serviceTask(urlRequestEncodable urlRequestEncodable: URLRequestEncodable) -> ServiceTask {
-        let task = ServiceTask(urlRequestEncodable: urlRequestEncodable, dataTaskSource: dataTaskSource)
-        
-        if startTasksImmediately {
-            task.resume()
-        }
-        
-        return task
-    }
-    
+extension WebService {
     /**
     Create a service task to fulfill a service request. By default the service
     task is started by calling resume(). To prevent service tasks from
@@ -179,15 +133,12 @@ extension WebService: RequestEncoder {
     - parameter method: HTTP request method.
     - parameter path: Request path. The value can be relative to the base URL string
     or absolute.
-    - parameter parameters: Optional request parameters.
-    - parameter options: Optional endpoint options used to configure the HTTP request.
     - returns: A ServiceTask instance that refers to the lifetime of processing
-    a given request. The newly created task is resumed immediately if the
-    `startTasksImmediately` poperty is set to `true`.
+    a given request.
     */
-    func request(method: Request.Method, path: String, parameters: [String : AnyObject]? = nil, options: [Request.Option]? = nil) -> ServiceTask {
-        let request = encodeRequest(method, url: absoluteURLString(path), parameters: parameters, options: options)
-        return serviceTask(urlRequestEncodable: request)
+    func request(method: Request.Method, path: String) -> ServiceTask {
+        let request = Request(method, url: absoluteURLString(path))
+        return ServiceTask(request: request, dataTaskSource: serviceDataTaskSource)
     }
 }
 
@@ -219,8 +170,20 @@ extension WebService {
 
 // MARK: - SessionDataTaskDataSource
 
-struct DataTaskDataSource: SessionDataTaskDataSource {
-    func dataTaskWithRequest(request: NSURLRequest, completion: (NSData?, NSURLResponse?, NSError?) -> Void) -> NSURLSessionDataTask? {
-        return NSURLSession.sharedSession().dataTaskWithRequest(request, completionHandler: completion);
+extension WebService: SessionDataTaskDataSource {
+    var serviceDataTaskSource: SessionDataTaskDataSource {
+        if let dataTaskSource = dataTaskSource {
+            return dataTaskSource
+        } else {
+            return self
+        }
+    }
+    
+    public func dataTaskWithRequest(request: NSURLRequest, completion: (NSData?, NSURLResponse?, NSError?) -> Void) -> NSURLSessionDataTask? {
+        if let task = dataTaskSource?.dataTaskWithRequest(request, completion: completion) {
+            return task
+        } else {
+            return NSURLSession.sharedSession().dataTaskWithRequest(request, completionHandler: completion);
+        }
     }
 }

--- a/THGWebService.xcodeproj/project.pbxproj
+++ b/THGWebService.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		17D1E56E1AD5538000384D2D /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D1E56B1AD5538000384D2D /* Request.swift */; };
 		17D1E56F1AD5538000384D2D /* ServiceTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D1E56C1AD5538000384D2D /* ServiceTask.swift */; };
 		17D1E5701AD5538000384D2D /* WebService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D1E56D1AD5538000384D2D /* WebService.swift */; };
+		17E34E021BE994FB0068866A /* SessionDataTaskDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E34E011BE994FB0068866A /* SessionDataTaskDataSource.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,6 +54,7 @@
 		17D1E56B1AD5538000384D2D /* Request.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
 		17D1E56C1AD5538000384D2D /* ServiceTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServiceTask.swift; sourceTree = "<group>"; };
 		17D1E56D1AD5538000384D2D /* WebService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebService.swift; sourceTree = "<group>"; };
+		17E34E011BE994FB0068866A /* SessionDataTaskDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionDataTaskDataSource.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -136,6 +138,7 @@
 				17D1E56B1AD5538000384D2D /* Request.swift */,
 				17D1E56C1AD5538000384D2D /* ServiceTask.swift */,
 				17D1E56D1AD5538000384D2D /* WebService.swift */,
+				17E34E011BE994FB0068866A /* SessionDataTaskDataSource.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -252,6 +255,7 @@
 			files = (
 				17D1E5701AD5538000384D2D /* WebService.swift in Sources */,
 				17D1E56F1AD5538000384D2D /* ServiceTask.swift in Sources */,
+				17E34E021BE994FB0068866A /* SessionDataTaskDataSource.swift in Sources */,
 				17D1E56E1AD5538000384D2D /* Request.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/THGWebService.xcodeproj/project.pbxproj
+++ b/THGWebService.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1705EE861BEC4CB700FB375E /* ServiceTaskResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1705EE851BEC4CB700FB375E /* ServiceTaskResult.swift */; };
 		178412251B1672E200EECF8B /* THGWebService.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 179C5C5E1AB079980047169F /* THGWebService.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		179C5C6A1AB079980047169F /* THGWebService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 179C5C5E1AB079980047169F /* THGWebService.framework */; };
 		17C96AAB1AB0CBB800D49071 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 17C96AAA1AB0CBB800D49071 /* LICENSE */; };
@@ -43,6 +44,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1705EE851BEC4CB700FB375E /* ServiceTaskResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServiceTaskResult.swift; sourceTree = "<group>"; };
 		179C5C5E1AB079980047169F /* THGWebService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = THGWebService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		179C5C691AB079980047169F /* THGWebServiceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = THGWebServiceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		179C5C6F1AB079980047169F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -139,6 +141,7 @@
 				17D1E56C1AD5538000384D2D /* ServiceTask.swift */,
 				17D1E56D1AD5538000384D2D /* WebService.swift */,
 				17E34E011BE994FB0068866A /* SessionDataTaskDataSource.swift */,
+				1705EE851BEC4CB700FB375E /* ServiceTaskResult.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -253,6 +256,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1705EE861BEC4CB700FB375E /* ServiceTaskResult.swift in Sources */,
 				17D1E5701AD5538000384D2D /* WebService.swift in Sources */,
 				17D1E56F1AD5538000384D2D /* ServiceTask.swift in Sources */,
 				17E34E021BE994FB0068866A /* SessionDataTaskDataSource.swift in Sources */,

--- a/THGWebServiceTests/WebServiceTests.swift
+++ b/THGWebServiceTests/WebServiceTests.swift
@@ -46,7 +46,40 @@ class WebServiceTests: XCTestCase {
         }
     }
 
-    // MARK: Tests  
+    // MARK: Tests
+    
+    func testUpdateUI() {
+        let successExpectation = expectationWithDescription("Received status 200")
+        let uiExpectation = expectationWithDescription("Received status 200")
+        let service = WebService(baseURLString: baseURL)
+        
+        let task = service
+            .GET("/get")
+            .response { data, response in
+                XCTAssertTrue(!NSThread.isMainThread())
+                
+                let httpResponse = response as! NSHTTPURLResponse
+                
+                if httpResponse.statusCode == 200 {
+                    successExpectation.fulfill()
+                }
+                
+                return ServiceTaskResult.Value(true)
+            }
+            .updateUI { value in
+                XCTAssertTrue(NSThread.isMainThread())
+
+                if let value = value as? Bool where value == true {
+                    uiExpectation.fulfill()
+                } else {
+                    fatalError()
+                }
+            }
+            .resume()
+        
+        XCTAssertEqual(task.state, NSURLSessionTaskState.Running, "Task should be running by default")
+        waitForExpectationsWithTimeout(2, handler: nil)
+    }
     
     func testGetEndpoint() {
         let successExpectation = expectationWithDescription("Received status 200")

--- a/THGWebServiceTests/WebServiceTests.swift
+++ b/THGWebServiceTests/WebServiceTests.swift
@@ -334,34 +334,5 @@ class WebServiceTests: XCTestCase {
         
         waitForExpectationsWithTimeout(2, handler: nil)
     }
-    
-    func testFoo() {
-        let service = WebService(baseURLString: baseURL)
-        let successExpectation = expectationWithDescription("Received status 200")
-
-        service
-            .POST("/post")
-                .setHeaderValue("Custom-Header", forName: "bar")
-                .setParameters(["foo" : "this needs percent encoded"])
-            .response { data, res in
-                let httpResponse = res as! NSHTTPURLResponse
-                
-                if httpResponse.statusCode == 200 {
-                    successExpectation.fulfill()
-                }
-            }
-            .resume()
-        
-        waitForExpectationsWithTimeout(5.0, handler: nil)
-        
-        /**
-        
-        POST /stores HTTP/1.1
-        Custom-Header: bar
-        Content-Length: 55
-        
-        foo=this%20needs%20percent%20encoded
-        */
-    }
 }
 

--- a/THGWebServiceTests/WebServiceTests.swift
+++ b/THGWebServiceTests/WebServiceTests.swift
@@ -22,6 +22,8 @@ class WebServiceTests: XCTestCase {
     
     func responseHandler(expectation expectation: XCTestExpectation) -> (NSData?, NSURLResponse?) -> ServiceTaskResult {
         return { data, response in
+            XCTAssertTrue(!NSThread.isMainThread())
+
             let httpResponse = response as! NSHTTPURLResponse
             
             if httpResponse.statusCode == 200 {
@@ -34,6 +36,8 @@ class WebServiceTests: XCTestCase {
     
     func jsonResponseHandler(expectation expectation: XCTestExpectation) -> (AnyObject) -> ServiceTaskResult {
         return { json in
+            XCTAssertTrue(!NSThread.isMainThread())
+
             if json is NSDictionary {
                 expectation.fulfill()
             }
@@ -128,6 +132,7 @@ class WebServiceTests: XCTestCase {
                 return ServiceTaskResult.Empty
             }
             .responseError { error in
+                XCTAssertTrue(!NSThread.isMainThread())
                 XCTAssertFalse(wasResponseCalled, "Response should not be called for error cases")
                 errorExpectation.fulfill()
             }

--- a/THGWebServiceTests/WebServiceTests.swift
+++ b/THGWebServiceTests/WebServiceTests.swift
@@ -135,27 +135,30 @@ class WebServiceTests: XCTestCase {
 
         waitForExpectationsWithTimeout(2, handler: nil)
     }
-//    
-//    func testSpecifyingResponseHandlerQueue() {
-//        let successExpectation = expectationWithDescription("Received status 200")
-//        let backgroundExpectation = expectationWithDescription("Background handler ran")
-//        let service = WebService(baseURLString: baseURL)
-//        let queue = dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0)
-//
-//        let task = service
-//            .GET("/get")
-//            .response(queue) { data, response in
-//                backgroundExpectation.fulfill()
-//            }
-//            .response { data, response in
-//                successExpectation.fulfill()
-//            }
-//            .resume()
-//        
-//        XCTAssertEqual(task.state, NSURLSessionTaskState.Running, "Task should be running by default")
-//        waitForExpectationsWithTimeout(4, handler: nil)
-//    }
-//    
+    
+    func testUpdateErrorUIHandler() {
+        let baseURL = "httpppppp://httpbin.org/"
+        let errorExpectation = expectationWithDescription("Error handler called for bad URL")
+        var wasResponseCalled = false
+        
+        WebService(baseURLString: baseURL)
+            .GET("/")
+            .response { data, response in
+                wasResponseCalled = true
+                return ServiceTaskResult.Empty
+            }
+            .updateErrorUI { error in
+                XCTAssertTrue(NSThread.isMainThread())
+                XCTAssertFalse(wasResponseCalled, "Response should not be called for error cases")
+                errorExpectation.fulfill()
+            }
+            .resume()
+        
+        waitForExpectationsWithTimeout(2, handler: nil)
+    }
+    
+    
+    
     func testGetJSON() {
         let successExpectation = expectationWithDescription("Received status 200")
         let handler = jsonResponseHandler(expectation: successExpectation)
@@ -168,20 +171,6 @@ class WebServiceTests: XCTestCase {
         XCTAssertEqual(task.state, NSURLSessionTaskState.Running, "Task should be running by default")
         waitForExpectationsWithTimeout(2, handler: nil)
     }
-    
-//    func testGetJSONWithSpecificQueue() {
-//        let successExpectation = expectationWithDescription("Received status 200")
-//        let handler = jsonResponseHandler(expectation: successExpectation)
-//        let service = WebService(baseURLString: baseURL)
-//        let queue = dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0)
-//        let task = service
-//            .GET("/get")
-//            .responseJSON(queue, handler: handler)
-//            .resume()
-//
-//        XCTAssertEqual(task.state, NSURLSessionTaskState.Running, "Task should be running by default")
-//        waitForExpectationsWithTimeout(2, handler: nil)
-//    }
     
     func testGetPercentEncodedParameters() {
         let successExpectation = expectationWithDescription("Received status 200")

--- a/THGWebServiceTests/WebServiceTests.swift
+++ b/THGWebServiceTests/WebServiceTests.swift
@@ -49,7 +49,8 @@ class WebServiceTests: XCTestCase {
         let task = service
                     .GET("/get")
                     .response(handler)
-        
+                    .resume()
+
         XCTAssertEqual(task.state, NSURLSessionTaskState.Running, "Task should be running by default")
         waitForExpectationsWithTimeout(2, handler: nil)
     }
@@ -68,7 +69,8 @@ class WebServiceTests: XCTestCase {
         let task = service
             .GET("http://httpbin.org/get")
             .response(handler)
-        
+            .resume()
+
         XCTAssertEqual(task.state, NSURLSessionTaskState.Running, "Task should be running by default")
         waitForExpectationsWithTimeout(2, handler: nil)
     }
@@ -80,6 +82,7 @@ class WebServiceTests: XCTestCase {
         let task = service
             .POST("/post")
             .response(handler)
+            .resume()
         
         XCTAssertEqual(task.state, NSURLSessionTaskState.Running, "Task should be running by default")
         waitForExpectationsWithTimeout(2, handler: nil)
@@ -92,7 +95,8 @@ class WebServiceTests: XCTestCase {
         let task = service
             .PUT("/put")
             .response(handler)
-        
+            .resume()
+
         XCTAssertEqual(task.state, NSURLSessionTaskState.Running, "Task should be running by default")
         waitForExpectationsWithTimeout(2, handler: nil)
     }
@@ -104,20 +108,10 @@ class WebServiceTests: XCTestCase {
         let task = service
             .DELETE("/delete")
             .response(handler)
+            .resume()
         
         XCTAssertEqual(task.state, NSURLSessionTaskState.Running, "Task should be running by default")
         waitForExpectationsWithTimeout(2, handler: nil)
-    }
-    
-    func testDisableStartTasksImmediately() {
-        let baseURL = "http://httpbin.org/"
-        
-        var service = WebService(baseURLString: baseURL)
-        service.startTasksImmediately = false
-        
-        let task = service.GET("/get")
-
-        XCTAssertEqual(task.state, NSURLSessionTaskState.Suspended, "Task should be suspended when startTasksImmediately is disabled")
     }
 
     func testErrorHandler() {
@@ -134,7 +128,8 @@ class WebServiceTests: XCTestCase {
                 XCTAssertFalse(wasResponseCalled, "Response should not be called for error cases")
                 errorExpectation.fulfill()
             }
-        
+            .resume()
+
         waitForExpectationsWithTimeout(2, handler: nil)
     }
     
@@ -151,7 +146,8 @@ class WebServiceTests: XCTestCase {
             }
             .response { data, response in
                 successExpectation.fulfill()
-        }
+            }
+            .resume()
         
         XCTAssertEqual(task.state, NSURLSessionTaskState.Running, "Task should be running by default")
         waitForExpectationsWithTimeout(4, handler: nil)
@@ -164,7 +160,8 @@ class WebServiceTests: XCTestCase {
         let task = service
             .GET("/get")
             .responseJSON(handler)
-        
+            .resume()
+
         XCTAssertEqual(task.state, NSURLSessionTaskState.Running, "Task should be running by default")
         waitForExpectationsWithTimeout(2, handler: nil)
     }
@@ -177,7 +174,8 @@ class WebServiceTests: XCTestCase {
         let task = service
             .GET("/get")
             .responseJSON(queue, handler: handler)
-        
+            .resume()
+
         XCTAssertEqual(task.state, NSURLSessionTaskState.Running, "Task should be running by default")
         waitForExpectationsWithTimeout(2, handler: nil)
     }
@@ -188,7 +186,8 @@ class WebServiceTests: XCTestCase {
         let parameters = ["foo" : "bar", "percentEncoded" : "this needs percent encoded"]
         
         service
-            .GET("/get", parameters: parameters)
+            .GET("/get")
+                .setParameters(parameters)
             .response { data, response in
                 
                 let httpResponse = response as! NSHTTPURLResponse
@@ -206,7 +205,8 @@ class WebServiceTests: XCTestCase {
                 
                 RequestTests.assertRequestParametersNotEqual(deliveredParameters!, toOriginalParameters: parameters)
             }
-        
+            .resume()
+
         waitForExpectationsWithTimeout(2, handler: nil)
     }
     
@@ -216,7 +216,8 @@ class WebServiceTests: XCTestCase {
         let parameters = ["foo" : "bar", "percentEncoded" : "this needs percent encoded"]
         
         service
-            .POST("/post", parameters: parameters)
+            .POST("/post")
+                .setParameters(parameters)
             .response { data, response in
                 
                 let httpResponse = response as! NSHTTPURLResponse
@@ -233,8 +234,9 @@ class WebServiceTests: XCTestCase {
                 XCTAssert(deliveredParameters != nil)
                 
                 RequestTests.assertRequestParametersNotEqual(deliveredParameters!, toOriginalParameters: parameters)
-        }
-        
+            }
+            .resume()
+
         waitForExpectationsWithTimeout(2, handler: nil)
     }
     
@@ -244,9 +246,8 @@ class WebServiceTests: XCTestCase {
         let parameters = ["foo" : "bar", "number" : 42]
         
         service
-            .POST("/post",
-                parameters: parameters,
-                options: [.ParameterEncoding(.JSON)])
+            .POST("/post")
+                .setParameters(parameters, encoding: .JSON)
             .response { data, response in
                 
                 let httpResponse = response as! NSHTTPURLResponse
@@ -263,7 +264,8 @@ class WebServiceTests: XCTestCase {
                 XCTAssert(deliveredParameters != nil)
                 
                 RequestTests.assertRequestParametersNotEqual(deliveredParameters!, toOriginalParameters: parameters)
-        }
+            }
+            .resume()
         
         waitForExpectationsWithTimeout(2, handler: nil)
     }
@@ -276,12 +278,9 @@ class WebServiceTests: XCTestCase {
         let jsonArray = [jsonObject, jsonObject]
         
         service
-            .POST("/post",
-                parameters: nil,
-                options: [
-                    .ParameterEncoding(.JSON),
-                    .BodyJSON(jsonArray)
-                ])
+            .POST("/post")
+                .setParameterEncoding(.JSON)
+                .setJSON(jsonArray)
             .response { data, response in
                 
                 let httpResponse = response as! NSHTTPURLResponse
@@ -300,7 +299,8 @@ class WebServiceTests: XCTestCase {
                 for deliveredJSONObject in deliveredArray! {
                     RequestTests.assertRequestParametersNotEqual(deliveredJSONObject, toOriginalParameters: jsonObject)
                 }
-        }
+            }
+            .resume()
         
         waitForExpectationsWithTimeout(2, handler: nil)
     }
@@ -308,12 +308,11 @@ class WebServiceTests: XCTestCase {
     func testHeadersDelivered() {
         let successExpectation = expectationWithDescription("Received status 200")
         let service = WebService(baseURLString: baseURL)
-        let headers = ["Some-Test-Header" :"testValue"]
+        let headers =  ["Some-Test-Header" :"testValue"]
         
         service
-            .GET("/get",
-                parameters: nil,
-                options: [.Header("Some-Test-Header", "testValue")])
+            .GET("/get")
+                .setHeaders(headers)
             .response { data, response in
                 
                 let httpResponse = response as! NSHTTPURLResponse
@@ -330,9 +329,39 @@ class WebServiceTests: XCTestCase {
                 XCTAssert(deliveredHeaders != nil)
                 
                 RequestTests.assertRequestParametersNotEqual(deliveredHeaders!, toOriginalParameters: headers)
-        }
+            }
+            .resume()
         
         waitForExpectationsWithTimeout(2, handler: nil)
+    }
+    
+    func testFoo() {
+        let service = WebService(baseURLString: baseURL)
+        let successExpectation = expectationWithDescription("Received status 200")
+
+        service
+            .POST("/post")
+                .setHeaderValue("Custom-Header", forName: "bar")
+                .setParameters(["foo" : "this needs percent encoded"])
+            .response { data, res in
+                let httpResponse = res as! NSHTTPURLResponse
+                
+                if httpResponse.statusCode == 200 {
+                    successExpectation.fulfill()
+                }
+            }
+            .resume()
+        
+        waitForExpectationsWithTimeout(5.0, handler: nil)
+        
+        /**
+        
+        POST /stores HTTP/1.1
+        Custom-Header: bar
+        Content-Length: 55
+        
+        foo=this%20needs%20percent%20encoded
+        */
     }
 }
 


### PR DESCRIPTION
fixes issues #7 and #8

builds on the work done in PR https://github.com/TheHolyGrail/Swallow/pull/10

## summary

- handler blocks set by the `response()`, `responseJSON()`, and `responseError()` methods now run serially on a bg queue instead of on the main queue
- added `updateUI()` method to add response handlers to the chain that will be dispatched to the main queue
- added `updateErrorUI()` method to add error handlers to the chain that will be dispatched to the main queue

## details

Introduces `ServiceTaskResult` enum to control how values flow through the handler chain. This allows response handlers to run on the bg thread and pass processed data to the next response handler in the chain.

- return `.Empty` to provide no processed value to the next handler
- return `.Value(AnyObject)` with an associated value of `AnyObject` type to provide a resulting value to the next handler in the chain
- return `.Failure(ErrorType)` with an associated value of `ErrorType` to prevent any consecutive response handlers from running. All registered error handlers will run instead. 

## example

```
service
  .GET("/foo")
  .response { data, response in
      let httpResponse = response as! NSHTTPURLResponse
      
      // only accept 200 status code repsonses
      if httpResponse.statusCode == 200 {
        return .Value(true)
      } else {
        var error: ErrorType
        return .Failure(error)
      }
  }
  .responseJSON { json in
      // process json on bg thread
      return .Value(Model(json: json))
  }
  .updateUI { value: AnyObject in
      // update UI on main thread
      if let model = value as? Model {
          view.configureWithModel(model)
      }
  }
  .resume()
```
