### PR TITLE
encode request parameters only when parameters are non empty

### DIFF
--- a/Source/Core/Request.swift
+++ b/Source/Core/Request.swift
@@ -172,18 +172,20 @@ extension Request: URLRequestEncodable {
             urlRequest.addValue(value, forHTTPHeaderField: name)
         }
         
-        switch method {
-        case .GET, .DELETE:
-            if let url = urlRequest.URL,
-                encodedURL = parameterEncoding.encodeURL(url, parameters: parameters) {
-                    urlRequest.URL = encodedURL
-            }
-        default:
-            if let data = parameterEncoding.encodeBody(parameters) {
-                urlRequest.HTTPBody = data
-                
-                if urlRequest.valueForHTTPHeaderField(Headers.contentType) == nil {
-                    urlRequest.setValue(ContentType.formEncoded, forHTTPHeaderField: Headers.contentType)
+        if parameters.count > 0 {
+            switch method {
+            case .GET, .DELETE:
+                if let url = urlRequest.URL,
+                    encodedURL = parameterEncoding.encodeURL(url, parameters: parameters) {
+                        urlRequest.URL = encodedURL
+                }
+            default:
+                if let data = parameterEncoding.encodeBody(parameters) {
+                    urlRequest.HTTPBody = data
+                    
+                    if urlRequest.valueForHTTPHeaderField(Headers.contentType) == nil {
+                        urlRequest.setValue(ContentType.formEncoded, forHTTPHeaderField: Headers.contentType)
+                    }
                 }
             }
         }

--- a/THGWebServiceTests/RequestTests.swift
+++ b/THGWebServiceTests/RequestTests.swift
@@ -137,4 +137,13 @@ class RequestTests: XCTestCase {
             fatalError("Failed to cast JSON as [String : AnyObject]")
         }
     }
+    
+    func test_urlRequestValue_validURLWithEmptyParameters() {
+        let request = Request(.GET, url: "http://httpbin.org/")
+        let urlRequest = request.urlRequestValue
+        let urlString = urlRequest.URL?.absoluteString
+
+        XCTAssertNotNil(urlString)
+        XCTAssertFalse(urlString!.containsString("?"))
+    }
 }


### PR DESCRIPTION
fixes an issue where request URLs would end with a `?` character when sending GET requests with empty parameters